### PR TITLE
Fix escaping for password for alembic migrations

### DIFF
--- a/superset/migrations/env.py
+++ b/superset/migrations/env.py
@@ -43,7 +43,8 @@ if "sqlite" in DATABASE_URI:
         "SQLite Database support for metadata databases will \
         be removed in a future version of Superset."
     )
-decoded_uri = urllib.parse.unquote(DATABASE_URI)
+# Note: this should really be done only for the password portion of the URI:
+decoded_uri = urllib.parse.unquote(DATABASE_URI).replace("%", "%%")
 config.set_main_option("sqlalchemy.url", decoded_uri)
 target_metadata = Base.metadata  # pylint: disable=no-member
 


### PR DESCRIPTION
There is a bug in the current superset tip where passwords with a `%` are not handled correctly in the alembic migration script (they are handled appropriately elsewhere). 

This recent PR: https://github.com/apache/superset/issues/23176 was designed to handle URLs with a `@` symbol, but does not work for passwords with`%` signs. The root cause is clearly documented [here](https://alembic.sqlalchemy.org/en/latest/api/config.html#alembic.config.Config.set_main_option), in that `set_main_option` requires escaping of `%` characters. 

Just setting the escaped password as the secret value does not work, as that value is used correctly elsewhere for db connections (with correct escape character handling), so in those instances you get password errors due to the extra character.

I will probably submit an issue and bug fix to the superset repo, but my fix here isn't the best, as it should only do the replacement within the password portion of the URI, and not the whole string (I don't believe you can validly have `%` characters elsewhere in the URI, but still). That way we won't need to maintain a fork (albeit this is a trivial one). Another fix would be just have a password that has no `%` characters in it. 😄 

To build the image:
```
docker build --target lean -t 059500544108.dkr.ecr.us-west-2.amazonaws.com/promethium-superset:base .
```
I have pushed this to the registry for staging so no CI is needed (it is not required for production as that used image promotion within the CI pipeline).